### PR TITLE
Break out fight tracking into its own pid

### DIFF
--- a/src/openomf_lobby_app.erl
+++ b/src/openomf_lobby_app.erl
@@ -7,7 +7,7 @@
 start(_StartType, _StartArgs) ->
     ListeningPort = 2098,
     ConnectFun = fun(PeerInfo) ->
-                         openomf_lobby_sup:start_client(PeerInfo)
+                         openomf_lobby_client_sup:start_client(PeerInfo)
                  end,
     Options = [{peer_limit, 10}, {channel_limit, 3}],
     {ok, Host} = enet:start_host(ListeningPort, ConnectFun, Options),

--- a/src/openomf_lobby_client.erl
+++ b/src/openomf_lobby_client.erl
@@ -6,15 +6,15 @@
 
 -record(state, {peer_info :: map(),
                 peer_pid :: pid(),
+                match_pid :: undefined | pid(),
                 protocol_version :: non_neg_integer(),
                 name :: undefined | binary(),
-                version :: undefined | binary(),
-                challenger :: undefined | pos_integer(),
-                challengee :: undefined | pos_integer()}).
+                version :: undefined | binary()
+               }).
 
 -export([start_link/1, init/1, handle_call/3, handle_cast/2, handle_info/2]).
 
--export([get_presence/2]).
+-export([get_presence/2, challenge/4, announce/2]).
 
 -define(PACKET_JOIN, 1).
 -define(PACKET_YELL, 2).
@@ -24,11 +24,14 @@
 -define(PACKET_PRESENCE, 6).
 -define(PACKET_CONNECTED, 7).
 -define(PACKET_REFRESH, 8).
+-define(PACKET_ANNOUNCEMENT, 9).
 
--define(CHALLENGE_FLAG_ACCEPT, 1).
--define(CHALLENGE_FLAG_REJECT, 2).
--define(CHALLENGE_FLAG_CANCEL, 4).
--define(CHALLENGE_FLAG_DONE, 8).
+-define(CHALLENGE_OFFER, 1).
+-define(CHALLENGE_ACCEPT, 1).
+-define(CHALLENGE_REJECT, 2).
+-define(CHALLENGE_CANCEL, 3).
+-define(CHALLENGE_DONE, 4).
+-define(CHALLENGE_ERROR, 5).
 
 -define(JOIN_ERROR_NAME_USED, 1).
 -define(JOIN_ERROR_NAME_INVALID, 2).
@@ -46,6 +49,12 @@
 get_presence(Pid, Dest) ->
     gen_server:cast(Pid, {get_presence, Dest}).
 
+challenge(Pid, MatchPid, ConnectID, Version) ->
+    gen_server:cast(Pid, {challenge, MatchPid, ConnectID, Version}).
+
+announce(Pid, Message) ->
+    gen_server:cast(Pid, {announce, Message}).
+
 start_link(PeerInfo) ->
     gen_server:start_link(?MODULE, PeerInfo, []).
 
@@ -61,14 +70,87 @@ handle_call(_, _, State) ->
     {reply, error, State}.
 
 handle_cast({get_presence, From}, State = #state{name=Name, version=Version}) when is_binary(Name) ->
-    Info = maps:put(version, Version, maps:put(name, Name, State#state.peer_info)),
-    gen_server:cast(From, {presence, encode_peer_to_presence(Info, 0)}),
+    gen_server:cast(From, {presence, encode_peer_to_presence(State#state.peer_info, 0)}),
     {noreply, State};
+
+handle_cast({challenge, From, ChallengerID, Version}, State = #state{name=Name, version=Version, match_pid=undefined, peer_info=PeerInfo}) when is_binary(Name) ->
+    gen_server:cast(From, {info, self(), PeerInfo}),
+    Packet = <<?PACKET_CHALLENGE:4/integer, 0:4/integer, ChallengerID:32/integer-unsigned-big>>,
+    Channels = maps:get(channels, PeerInfo),
+    Channel = maps:get(0, Channels),
+    enet:send_reliable(Channel, Packet),
+    PeerInfo2 = maps:put(status, ?PRESENCE_PONDERING, PeerInfo),
+    enet:broadcast_reliable(2098, 0, encode_peer_to_presence(PeerInfo2, 0)),
+    %% TODO 
+    {noreply, State#state{match_pid=From, peer_info=PeerInfo2}};
+
+handle_cast({challenge, From, _ChallengerID, _Version}, State = #state{name=Name, match_pid=MatchPid}) when is_binary(Name), is_pid(MatchPid) ->
+    %% match pid is not undefined, so reject it
+    gen_server:cast(From, {busy, self()}),
+    {noreply, State};
+
+handle_cast({challenge, From, _ChallengerID, TheirVersion}, State = #state{name=Name, version=OurVersion, match_pid=undefined}) when is_binary(Name) andalso TheirVersion /= OurVersion ->
+    gen_server:cast(From, {incompatible, self()}),
+    %% TODO 
+    {noreply, State};
+
+handle_cast(accepted, State = #state{peer_info=PeerInfo, match_pid = MatchPid}) when is_pid(MatchPid) ->
+    Packet = <<?PACKET_CHALLENGE:4/integer, ?CHALLENGE_ACCEPT:4/integer>>,
+    Channels = maps:get(channels, PeerInfo),
+    Channel = maps:get(0, Channels),
+    enet:send_reliable(Channel, Packet),
+    {noreply, State};
+
+handle_cast({set_state, GameState}, State = #state{peer_info=PeerInfo}) ->
+    NewPresence =
+    case GameState of
+        fighting ->
+            ?PRESENCE_FIGHTING;
+        watching ->
+            ?PRESENCE_WATCHING;
+        available ->
+            ?PRESENCE_AVAILABLE;
+        pondering ->
+            ?PRESENCE_PONDERING;
+        starting ->
+            ?PRESENCE_STARTING;
+        practicing ->
+            ?PRESENCE_PRACTICING;
+        challenging ->
+            ?PRESENCE_PRACTICING;
+        Other ->
+            lager:info("client being set to unknown presence ~p", [Other]),
+            ?PRESENCE_UNKNOWN
+    end,
+
+    PeerInfo2 = maps:put(status, NewPresence, PeerInfo),
+    enet:broadcast_reliable(2098, 0, encode_peer_to_presence(PeerInfo2, 0)),
+    {noreply, State#state{peer_info=PeerInfo2}};
+
+handle_cast(won, State = #state{peer_info=PeerInfo}) ->
+    NewPeerInfo = maps:put(wins, maps:get(wins, PeerInfo, 0) + 1, PeerInfo),
+    enet:broadcast_reliable(2098, 0, encode_peer_to_presence(NewPeerInfo, 0)),
+    {noreply, State#state{peer_info=NewPeerInfo}};
+
+handle_cast(lost, State = #state{peer_info=PeerInfo}) ->
+    NewPeerInfo = maps:put(losses, maps:get(losses, PeerInfo, 0) + 1, PeerInfo),
+    enet:broadcast_reliable(2098, 0, encode_peer_to_presence(NewPeerInfo, 0)),
+    {noreply, State#state{peer_info=NewPeerInfo}};
+
 handle_cast({presence, Msg}, State = #state{peer_info = PeerInfo}) ->
     Channels = maps:get(channels, PeerInfo),
-    Channel = maps:get(1, Channels),
+    Channel = maps:get(0, Channels),
     enet:send_reliable(Channel, Msg),
     {noreply, State};
+
+handle_cast({announce, Message}, State = #state{peer_info=PeerInfo}) ->
+    Channels = maps:get(channels, PeerInfo),
+    Channel = maps:get(0, Channels),
+
+    enet:send_reliable(Channel, <<?PACKET_ANNOUNCEMENT:4/integer, 0:4/integer, Message/binary, 0>>),
+
+    {noreply, State};
+
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
@@ -77,8 +159,43 @@ handle_info({'EXIT', PeerPid, _Reason}, State = #state{name=Name, peer_pid=PeerP
     RFU = 0,
     ConnectID = maps:get(connect_id, State#state.peer_info),
     user_leave_event(Name),
-    enet:broadcast_reliable(2098, 1, <<?PACKET_DISCONNECT:4/integer, RFU:4/integer, ConnectID:32/integer-unsigned-big>>),
+    enet:broadcast_reliable(2098, 0, <<?PACKET_DISCONNECT:4/integer, RFU:4/integer, ConnectID:32/integer-unsigned-big>>),
     {stop, normal, State};
+
+handle_info({'EXIT', MatchPid, Reason}, State = #state{match_pid = MatchPid, peer_info = PeerInfo}) ->
+    lager:info("match pid exited with ~p", [Reason]),
+    Packet =
+    case Reason of
+        normal ->
+            none;
+        cancel ->
+            <<?PACKET_CHALLENGE:4/integer, ?CHALLENGE_CANCEL:4/integer>>;
+        rejected ->
+            <<?PACKET_CHALLENGE:4/integer, ?CHALLENGE_REJECT:4/integer>>;
+        challengee_timeout ->
+            <<?PACKET_CHALLENGE:4/integer, ?CHALLENGE_ERROR:4/integer, "User is not responding">>;
+        challengee_incompatible ->
+            <<?PACKET_CHALLENGE:4/integer, ?CHALLENGE_ERROR:4/integer, "User is running an incompatible version of OpenOMF">>;
+        challengee_busy ->
+            <<?PACKET_CHALLENGE:4/integer, ?CHALLENGE_ERROR:4/integer, "User is busy">>;
+        Other ->
+            ErrorString = list_to_binary(io_lib:format("Failed to challenge user: ~p", [Other])),
+            <<?PACKET_CHALLENGE:4/integer, ?CHALLENGE_ERROR:4/integer, ErrorString/binary>>
+    end,
+
+    case is_binary(Packet) of
+        true ->
+            Channels = maps:get(channels, PeerInfo),
+            Channel = maps:get(0, Channels),
+
+            enet:send_reliable(Channel, Packet);
+        false ->
+            ok
+    end,
+
+    NewPeerInfo = maps:put(status, ?PRESENCE_AVAILABLE, PeerInfo),
+    enet:broadcast_reliable(2098, 0, encode_peer_to_presence(NewPeerInfo, 0)),
+    {noreply, State#state{peer_info=NewPeerInfo, match_pid=undefined}};
 
 handle_info({enet, _ChannelID, #unsequenced{ data = Packet }}, State) ->
     lager:info("got unsequenced packet ~p", [Packet]),
@@ -91,7 +208,6 @@ handle_info({enet, ChannelID, #reliable{ data = <<?PACKET_JOIN:4/integer, LobbyV
     lager:info("client has named themselves ~s and has an external port of ~p", [Name, ExtPort]),
     %% TODO check for a name conflict!
     %% and that the name is not too long, etc
-    Clients = openomf_lobby_sup:client_presence(),
     PeerInfo = State#state.peer_info,
     Channels = maps:get(channels, PeerInfo),
     Channel = maps:get(ChannelID, Channels),
@@ -100,10 +216,17 @@ handle_info({enet, ChannelID, #reliable{ data = <<?PACKET_JOIN:4/integer, LobbyV
 	    true ->
 		    %% confirm the join and tell the user their connect ID
 		    enet:send_reliable(Channel, <<?PACKET_JOIN:4/integer, 0:4/integer, ConnectID:32/integer-unsigned-big>>),
+        openomf_lobby_client_sup:client_presence(),
 		    %% broadcast the user join...
         PeerInfo2 = maps:put(status, ?PRESENCE_AVAILABLE, maps:put(external_port, ExtPort, maps:put(version, Version, maps:put(name, Name, State#state.peer_info)))),
-		    enet:broadcast_reliable(2098, 1, encode_peer_to_presence(PeerInfo2, 1)),
+		    enet:broadcast_reliable(2098, 0, encode_peer_to_presence(PeerInfo2, 1)),
 		    user_joined_event(Name),
+        case application:get_env(motd) of
+            undefined -> ok;
+            {ok, Message} ->
+                lager:info("motd is ~p", [Message]),
+                enet:send_reliable(Channel, <<?PACKET_ANNOUNCEMENT:4/integer, 0:4/integer, Message/binary, 0>>)
+        end,
 		    {noreply ,State#state{name = Name, version = Version, peer_info = PeerInfo2}}
 	    catch _:_ ->
 		    %% user already registered
@@ -147,67 +270,66 @@ handle_info({enet, _ChannelID, #reliable{ data = <<?PACKET_YELL:4/integer, 0:4/i
             ok
     end,
     lager:info("client ~p yelled ~s", [State#state.name, Yell]),
-    enet:broadcast_reliable(2098, 1, <<?PACKET_YELL:4/integer, 0:4/integer, Name/binary, ": ", Yell/binary, 0>>),
+    enet:broadcast_reliable(2098, 0, <<?PACKET_YELL:4/integer, 0:4/integer, Name/binary, ": ", Yell/binary, 0>>),
     {noreply ,State};
 
-handle_info({enet, _ChannelID, #reliable{ data = <<?PACKET_CHALLENGE:4/integer, ?CHALLENGE_FLAG_ACCEPT:4/integer>> }}, State = #state{peer_info=PeerInfo, challenger=Challenger}) when Challenger /= undefined ->
-    ConnectID = maps:get(connect_id, PeerInfo),
-    [Pid ! {challenge_accept, ConnectID} || Pid <- gproc:lookup_pids({n, l, {connect_id, Challenger}}) ],
-    PeerInfo2 = maps:put(status, ?PRESENCE_FIGHTING, PeerInfo),
-    enet:broadcast_reliable(2098, 1, encode_peer_to_presence(PeerInfo2, 0)),
-    {noreply, State#state{peer_info=PeerInfo2}};
-handle_info({enet, _ChannelID, #reliable{ data = <<?PACKET_CHALLENGE:4/integer, ?CHALLENGE_FLAG_REJECT:4/integer>> }}, State = #state{peer_info=PeerInfo, challenger=Challenger}) when Challenger /= undefined ->
-    ConnectID = maps:get(connect_id, PeerInfo),
-    [Pid ! {challenge_reject, ConnectID} || Pid <- gproc:lookup_pids({n, l, {connect_id, Challenger}}) ],
-    PeerInfo2 = maps:put(status, ?PRESENCE_AVAILABLE, PeerInfo),
-    enet:broadcast_reliable(2098, 1, encode_peer_to_presence(PeerInfo2, 0)),
-    {noreply, State#state{challenger=undefined, peer_info=PeerInfo2}};
-handle_info({enet, _ChannelID, #reliable{ data = <<?PACKET_CHALLENGE:4/integer, ?CHALLENGE_FLAG_CANCEL:4/integer>> }}, State = #state{peer_info=PeerInfo, challengee=Challengee}) when Challengee /= undefined ->
+handle_info({enet, _ChannelID, #reliable{ data = <<?PACKET_CHALLENGE:4/integer, ?CHALLENGE_ACCEPT:4/integer>> }}, State = #state{match_pid=MatchPid}) when MatchPid /= undefined ->
+    gen_statem:cast(MatchPid, accept),
+    {noreply, State};
+handle_info({enet, _ChannelID, #reliable{ data = <<?PACKET_CHALLENGE:4/integer, ?CHALLENGE_REJECT:4/integer>> }}, State = #state{match_pid=MatchPid}) when MatchPid /= undefined ->
+    unlink(MatchPid),
+    gen_statem:cast(MatchPid, reject),
+    PeerInfo2 = maps:put(status, ?PRESENCE_AVAILABLE, State#state.peer_info),
+    enet:broadcast_reliable(2098, 0, encode_peer_to_presence(PeerInfo2, 0)),
+    {noreply, State#state{match_pid=undefined, peer_info=PeerInfo2}};
+handle_info({enet, _ChannelID, #reliable{ data = <<?PACKET_CHALLENGE:4/integer, ?CHALLENGE_CANCEL:4/integer>> }}, State = #state{match_pid=MatchPid}) when MatchPid /= undefined ->
     %% user is cancelling their challenge
-    ConnectID = maps:get(connect_id, PeerInfo),
-    [Pid ! {challenge_cancel, ConnectID} || Pid <- gproc:lookup_pids({n, l, {connect_id, Challengee}}) ],
-    PeerInfo2 = maps:put(status, ?PRESENCE_AVAILABLE, PeerInfo),
-    enet:broadcast_reliable(2098, 1, encode_peer_to_presence(PeerInfo2, 0)),
-    {noreply, State#state{challengee=undefined, peer_info=PeerInfo2}};
-handle_info({enet, _ChannelID, #reliable{ data = <<?PACKET_CHALLENGE:4/integer, ?CHALLENGE_FLAG_DONE:4/integer, 0:8/integer>> }}, State = #state{peer_info=PeerInfo, challengee=Challengee, challenger=Challenger}) when Challengee /= undefined orelse Challenger /= undefined ->
-    NewPeerInfo = maps:put(status, ?PRESENCE_AVAILABLE, maps:put(wins, maps:get(wins, PeerInfo, 0) +1, PeerInfo)),
-    lager:info("~p won their match", [maps:get(name, PeerInfo)]),
-    enet:broadcast_reliable(2098, 1, encode_peer_to_presence(NewPeerInfo, 0)),
-    {noreply, State#state{peer_info=NewPeerInfo}};
-handle_info({enet, _ChannelID, #reliable{ data = <<?PACKET_CHALLENGE:4/integer, ?CHALLENGE_FLAG_DONE:4/integer, 1:8/integer>> }}, State = #state{peer_info=PeerInfo, challengee=Challengee, challenger=Challenger}) when Challengee /= undefined orelse Challenger /= undefined ->
-    NewPeerInfo = maps:put(status, ?PRESENCE_AVAILABLE, maps:put(losses, maps:get(losses, PeerInfo, 0) +1, PeerInfo)),
-    lager:info("~p lost their match", [maps:get(name, PeerInfo)]),
-    enet:broadcast_reliable(2098, 1, encode_peer_to_presence(NewPeerInfo, 0)),
-    {noreply, State#state{peer_info=NewPeerInfo}};
-
-handle_info({enet, _ChannelID, #reliable{ data = <<?PACKET_CHALLENGE:4/integer, ?CHALLENGE_FLAG_CANCEL:4/integer>> }}, State = #state{peer_info=PeerInfo, challenger=Challenger}) when Challenger /= undefined ->
-    %% user is cancelling their challenge
-    ConnectID = maps:get(connect_id, PeerInfo),
-    [Pid ! {challenge_cancel, ConnectID} || Pid <- gproc:lookup_pids({n, l, {connect_id, Challenger}}) ],
-    PeerInfo2 = maps:put(status, ?PRESENCE_AVAILABLE, PeerInfo),
-    enet:broadcast_reliable(2098, 1, encode_peer_to_presence(PeerInfo2, 0)),
-    {noreply, State#state{challenger=undefined, peer_info=PeerInfo2}};
-
-handle_info({enet, _ChannelID, #reliable{ data = <<?PACKET_CHALLENGE:4/integer, 0:4/integer, ID:32/integer-unsigned-big>> }}, State = #state{peer_info=PeerInfo, challengee=undefined, challenger=undefined}) ->
+    unlink(MatchPid),
+    gen_statem:cast(MatchPid, cancel),
+    PeerInfo2 = maps:put(status, ?PRESENCE_AVAILABLE, State#state.peer_info),
+    enet:broadcast_reliable(2098, 0, encode_peer_to_presence(PeerInfo2, 0)),
+    {noreply, State#state{match_pid=undefined, peer_info=PeerInfo2}};
+handle_info({enet, _ChannelID, #reliable{ data = <<?PACKET_CHALLENGE:4/integer, ?CHALLENGE_DONE:4/integer, Result:8/integer>> }}, State = #state{match_pid=MatchPid}) when MatchPid /= undefined ->
+    gen_statem:cast(MatchPid, {done, self(), Result}),
+   {noreply, State};
+handle_info({enet, ChannelID, #reliable{ data = <<?PACKET_CHALLENGE:4/integer, 0:4/integer, ID:32/integer-unsigned-big>> }}, State = #state{peer_info=PeerInfo, match_pid=undefined, version=Version}) ->
+    %% initiating a challenge
     ConnectID = maps:get(connect_id, PeerInfo),
     lager:info("~p is challenging ~p", [ConnectID, ID]),
-    PeerInfo2 = maps:put(status, ?PRESENCE_CHALLENGING, PeerInfo),
-    %% TODO monitor the pid, so if the other player disconnects we know
-    [Pid ! {challenge, <<?PACKET_CHALLENGE:4/integer, 0:4/integer, ConnectID:32/integer-unsigned-big>>} || Pid <- gproc:lookup_pids({n, l, {connect_id, ID}}) ],
-    enet:broadcast_reliable(2098, 1, encode_peer_to_presence(PeerInfo2, 0)),
-    {noreply ,State#state{challengee=ID, peer_info=PeerInfo2}};
+    Channels = maps:get(channels, PeerInfo),
+    Channel = maps:get(ChannelID, Channels),
+    case gproc:lookup_pids({n, l, {connect_id, ID}}) of
+        [Pid] ->
+            case openomf_lobby_match_sup:start_match(self(), PeerInfo, Pid) of
+                {ok, MatchPid} ->
+                    PeerInfo2 = maps:put(status, ?PRESENCE_CHALLENGING, PeerInfo),
+                    enet:broadcast_reliable(2098, 0, encode_peer_to_presence(PeerInfo2, 0)),
+                    {noreply, State#state{match_pid =MatchPid, peer_info=PeerInfo2}};
+                {error, Reason} ->
+                    lager:info("failed to challenge ~p", [Reason]),
+                    ErrorString = list_to_binary(io_lib:format("Failed to challenge user: ~p", [Reason])),
+                    enet:send_reliable(Channel, <<?PACKET_CHALLENGE:4/integer, ?CHALLENGE_ERROR:4/integer, ErrorString/binary>>),
+                    {noreply, State}
+            end;
+        _ ->
+            %% user not found, probably just disconnected
+            enet:send_reliable(Channel, <<?PACKET_CHALLENGE:4/integer, ?CHALLENGE_ERROR:4/integer, "User not found">>),
+            {noreply, State}
+    end;
 
-
-handle_info({enet, _ChannelID, #reliable{ data = <<?PACKET_CONNECTED:4/integer, 0:4/integer>> }}, State) ->
+handle_info({enet, _ChannelID, #reliable{ data = <<?PACKET_CONNECTED:4/integer, 0:4/integer>> }}, State = #state{match_pid = MatchPid}) when is_pid(MatchPid) ->
+    gen_statem:cast(MatchPid, {connected, self()}),
     lager:info("~p connected to peer", [State#state.name]),
     {noreply, State};
 
-handle_info({enet, _ChannelID, #reliable{ data = <<?PACKET_CONNECTED:4/integer, 1:4/integer>> }}, State) ->
+handle_info({enet, _ChannelID, #reliable{ data = <<?PACKET_CONNECTED:4/integer, 1:4/integer>> }}, State = #state{match_pid = MatchPid}) when is_pid(MatchPid) ->
+    gen_statem:cast(MatchPid, {connect_failed, self(), 1}),
     lager:info("~p FAILED to connect to peer (first time)", [State#state.name]),
     {noreply, State};
 
-handle_info({enet, _ChannelID, #reliable{ data = <<?PACKET_CONNECTED:4/integer, 2:4/integer>> }}, State) ->
+handle_info({enet, _ChannelID, #reliable{ data = <<?PACKET_CONNECTED:4/integer, 2:4/integer>> }}, State = #state{match_pid = MatchPid}) when is_pid(MatchPid) ->
     lager:info("~p FAILED to connect to peer (second time)", [State#state.name]),
+    gen_statem:cast(MatchPid, {connect_failed, self(), 2}),
     %% TODO relay the game packets via the server once both sides have failed to connect 2x
     {noreply, State};
 
@@ -216,14 +338,13 @@ handle_info({enet, ChannelID, #reliable{ data = <<?PACKET_REFRESH:4/integer, _:4
     Channels = maps:get(channels, PeerInfo),
     Channel = maps:get(ChannelID, Channels),
 
-    Clients = openomf_lobby_sup:client_presence(),
+    openomf_lobby_client_sup:client_presence(),
     ConnectID = maps:get(connect_id, PeerInfo),
     %% tell the user their connect ID
     enet:send_reliable(Channel, <<?PACKET_JOIN:4/integer, 0:4/integer, ConnectID:32/integer-unsigned-big>>),
 
     enet:send_reliable(Channel, encode_peer_to_presence(PeerInfo, 0)),
-    % XXX clear the challengee/challenger state here for now
-    {noreply, State#state{challenger=undefined, challengee=undefined}};
+    {noreply, State};
 
 handle_info({enet, _ChannelID, #reliable{ data = Packet }}, State) ->
     lager:info("got reliable packet ~p", [Packet]),
@@ -233,42 +354,6 @@ handle_info({whisper, Packet}, State = #state{peer_info=PeerInfo}) ->
     Channel = maps:get(0, Channels),
     enet:send_reliable(Channel, Packet),
     {noreply, State};
-handle_info({challenge, <<?PACKET_CHALLENGE:4/integer, 0:4/integer, Challenger:32/integer-unsigned-big>> = Packet}, State = #state{peer_info=PeerInfo}) ->
-    %% TODO check if we are already challenging or being challenged.
-    %% TODO make this a call instead?
-    Channels = maps:get(channels, PeerInfo),
-    Channel = maps:get(0, Channels),
-    enet:send_reliable(Channel, Packet),
-    PeerInfo2 = maps:put(status, ?PRESENCE_PONDERING, PeerInfo),
-    enet:broadcast_reliable(2098, 1, encode_peer_to_presence(PeerInfo2, 0)),
-    {noreply, State#state{challenger=Challenger, peer_info=PeerInfo2}};
-handle_info({challenge_cancel, Challenger}, State = #state{peer_info=PeerInfo, challenger=Challenger}) when Challenger /= undefined ->
-    Channels = maps:get(channels, PeerInfo),
-    Channel = maps:get(0, Channels),
-    enet:send_reliable(Channel, <<?PACKET_CHALLENGE:4/integer, ?CHALLENGE_FLAG_CANCEL:4/integer>>),
-    PeerInfo2 = maps:put(status, ?PRESENCE_AVAILABLE, PeerInfo),
-    enet:broadcast_reliable(2098, 1, encode_peer_to_presence(PeerInfo2, 0)),
-    {noreply, State#state{challenger=undefined, peer_info=PeerInfo2}};
-handle_info({challenge_cancel, Challengee}, State = #state{peer_info=PeerInfo, challengee=Challengee}) when Challengee /= undefined ->
-    Channels = maps:get(channels, PeerInfo),
-    Channel = maps:get(0, Channels),
-    enet:send_reliable(Channel, <<?PACKET_CHALLENGE:4/integer, ?CHALLENGE_FLAG_CANCEL:4/integer>>),
-    {noreply, State#state{challengee=undefined}};
-handle_info({challenge_reject, Challengee}, State = #state{peer_info=PeerInfo, challengee=Challengee}) ->
-    Channels = maps:get(channels, PeerInfo),
-    Channel = maps:get(0, Channels),
-    enet:send_reliable(Channel, <<?PACKET_CHALLENGE:4/integer, ?CHALLENGE_FLAG_REJECT:4/integer>>),
-    PeerInfo2 = maps:put(status, ?PRESENCE_AVAILABLE, PeerInfo),
-    enet:broadcast_reliable(2098, 1, encode_peer_to_presence(PeerInfo2, 0)),
-    {noreply, State#state{challengee=undefined, peer_info=PeerInfo2}};
-handle_info({challenge_accept, Challengee}, State = #state{peer_info=PeerInfo, challengee=Challengee}) ->
-    Channels = maps:get(channels, PeerInfo),
-    Channel = maps:get(0, Channels),
-    enet:send_reliable(Channel, <<?PACKET_CHALLENGE:4/integer, ?CHALLENGE_FLAG_ACCEPT:4/integer>>),
-    PeerInfo2 = maps:put(status, ?PRESENCE_FIGHTING, PeerInfo),
-    enet:broadcast_reliable(2098, 1, encode_peer_to_presence(PeerInfo2, 0)),
-    {noreply, State#state{peer_info=PeerInfo2}};
-
 
 handle_info(Msg, State) ->
     lager:info("unhandled ~p", [Msg]),

--- a/src/openomf_lobby_client_sup.erl
+++ b/src/openomf_lobby_client_sup.erl
@@ -1,0 +1,34 @@
+-module(openomf_lobby_client_sup).
+
+-behaviour(supervisor).
+
+-export([start_link/0,
+         start_client/1, client_presence/0, announce/1]).
+
+-export([init/1]).
+
+start_link() ->
+      supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+init(_Args) ->
+    SupFlags = #{strategy => simple_one_for_one,
+                 intensity => 0,
+                 period => 1},
+    ChildSpecs = [#{id => openomf_lobby_client,
+                    start => {openomf_lobby_client, start_link, []},
+                    type => worker,
+                    restart => temporary,
+                    shutdown => brutal_kill}],
+    {ok, {SupFlags, ChildSpecs}}.
+
+start_client(PeerInfo) ->
+    supervisor:start_child(?MODULE, [PeerInfo]).
+
+client_presence() ->
+    Children = supervisor:which_children(?MODULE),
+    [ openomf_lobby_client:get_presence(Pid, self()) || {_Id, Pid, _Type, _Modules} <- Children, Pid /= self()].
+
+announce(Message) ->
+    Children = supervisor:which_children(?MODULE),
+    [ openomf_lobby_client:announce(Pid, Message) || {_Id, Pid, _Type, _Modules} <- Children].
+

--- a/src/openomf_lobby_match.erl
+++ b/src/openomf_lobby_match.erl
@@ -111,10 +111,10 @@ connected(cast, cancel, _Data) ->
     %% either side is cancelling
     {stop, cancel};
 connected(cast, {done, ChallengerPid, WonOrLost}, Data = #state{challenger_pid = ChallengerPid, challenger_won=undefined}) ->
-    NewData = Data#state{challenger_won = WonOrLost == 1},
+    NewData = Data#state{challenger_won = WonOrLost == 0},
     check_winner(NewData);
 connected(cast, {done, ChallengeePid, WonOrLost}, Data = #state{challengee_pid = ChallengeePid, challengee_won=undefined}) ->
-    NewData = Data#state{challengee_won = WonOrLost == 1},
+    NewData = Data#state{challengee_won = WonOrLost == 0},
     check_winner(NewData).
 
 

--- a/src/openomf_lobby_match.erl
+++ b/src/openomf_lobby_match.erl
@@ -1,0 +1,150 @@
+-module(openomf_lobby_match).
+
+-behaviour(gen_statem).
+
+-export([start_link/3]).
+
+-export([init/1,callback_mode/0]).%%,terminate/3]).
+
+-export([starting/3, challenging/3, connecting/3, connected/3]).
+
+-record(state, {
+          challenger_pid :: pid(),
+          challenger_info :: map(),
+          challengee_pid :: pid(),
+          challengee_info :: undefined | map(),
+          challenger_connected = false :: boolean(),
+          challengee_connected = false :: boolean(),
+          challenger_connect_count = 0 :: non_neg_integer(),
+          challengee_connect_count = 0 :: non_neg_integer(),
+          challenger_won = undefined :: undefined | boolean(),
+          challengee_won = undefined :: undefined | boolean()
+         }).
+
+start_link(ChallengerPid, ChallengerInfo, ChallengeePid) ->
+    gen_statem:start_link(?MODULE, [ChallengerPid, ChallengerInfo, ChallengeePid], []).
+
+init([ChallengerPid, ChallengerInfo, ChallengeePid]) ->
+    %% die if either party's process exits
+    %% clients trap_exit so they'll get a message
+    link(ChallengerPid),
+    link(ChallengeePid),
+    {ok, starting, #state{challenger_pid=ChallengerPid, challenger_info=ChallengerInfo, challengee_pid=ChallengeePid}}.
+
+callback_mode() ->
+    [state_functions,state_enter].
+
+
+starting(enter, _OldState, Data) ->
+    %% challenge the challengee
+    lager:info("sending challenge to ~p", Data#state.challengee_pid),
+    ChallengerID = maps:get(connect_id, Data#state.challenger_info),
+    Version = maps:get(version, Data#state.challenger_info),
+    openomf_lobby_client:challenge(Data#state.challengee_pid, self(), ChallengerID, Version),
+    {keep_state_and_data, [{state_timeout,10_000, challengee_timeout}]};
+starting(state_timeout, challengee_timeout, _Data) ->
+    %% challengee never responded
+    {stop, challengee_timeout};
+starting(cast, {info, ChallengeePid, ChallengeeInfo}, Data = #state{challengee_pid = ChallengeePid}) ->
+    %% version is confirmed to match by now, and the challengee didn't have a match pid already
+    {next_state, challenging, Data#state{challengee_info=ChallengeeInfo}};
+starting(cast, {busy, ChallengeePid}, #state{challengee_pid = ChallengeePid}) ->
+    {stop, challengee_busy};
+starting(cast, {incompatible, ChallengeePid}, #state{challengee_pid = ChallengeePid}) ->
+    {stop, challengee_incompatible};
+starting(cast, cancel, _Data) ->
+    %% challenger is cancelling
+    {stop, cancel}.
+
+challenging(enter, _OldState, _Data) ->
+    keep_state_and_data;
+challenging(cast, cancel, _Data) ->
+    %% challenger is cancelling
+    {stop, cancel};
+challenging(cast, reject, _Data) ->
+    %% challengee is rejecting
+    {stop, rejected};
+challenging(cast, accept, Data) ->
+    gen_server:cast(Data#state.challenger_pid, accepted),
+    %% challengee is accepting
+    {next_state, connecting, Data}.
+
+connecting(enter, _OldState, _Data) ->
+    keep_state_and_data;
+connecting(cast, {connected, ChallengerPid}, Data = #state{challenger_pid = ChallengerPid}) ->
+    NewData = Data#state{challenger_connected = true},
+    check_connected(NewData);
+connecting(cast, {connected, ChallengeePid}, Data = #state{challengee_pid = ChallengeePid}) ->
+    NewData = Data#state{challengee_connected = true},
+    check_connected(NewData);
+connecting(cast, {connect_failed, ChallengerPid, Count}, Data = #state{challenger_pid = ChallengerPid, challenger_connect_count = ChallengerConnectCount}) ->
+    NewData = Data#state{challenger_connect_count = Count + ChallengerConnectCount},
+    case Count + ChallengerConnectCount == 5 andalso Data#state.challengee_connect_count == 5 of
+        true ->
+            lager:info("Match should be relayed"),
+            {stop, relay_not_implemented};
+        false ->
+            {keep_state, NewData}
+    end;
+connecting(cast, {connect_failed, ChallengeePid, Count}, Data = #state{challengee_pid = ChallengeePid, challengee_connect_count = ChallengeeConnectCount}) ->
+    NewData = Data#state{challengee_connect_count = Count + ChallengeeConnectCount},
+    case Count + ChallengeeConnectCount == 5 andalso Data#state.challenger_connect_count == 5 of
+        true ->
+            lager:info("Match should be relayed"),
+            {stop, relay_not_implemented};
+        false ->
+            {keep_state, NewData}
+    end;
+connecting(cast, cancel, _Data) ->
+    %% either side is cancelling
+    {stop, cancel}.
+
+
+
+connected(enter, _OldState, Data) ->
+    lager:info("both sides are connected!"),
+    gen_server:cast(Data#state.challenger_pid, {set_state, fighting}),
+    gen_server:cast(Data#state.challengee_pid, {set_state, fighting}),
+    %% set both parties to 'fighting' state
+    keep_state_and_data;
+connected(cast, cancel, _Data) ->
+    %% either side is cancelling
+    {stop, cancel};
+connected(cast, {done, ChallengerPid, WonOrLost}, Data = #state{challenger_pid = ChallengerPid, challenger_won=undefined}) ->
+    NewData = Data#state{challenger_won = WonOrLost == 1},
+    check_winner(NewData);
+connected(cast, {done, ChallengeePid, WonOrLost}, Data = #state{challengee_pid = ChallengeePid, challengee_won=undefined}) ->
+    NewData = Data#state{challengee_won = WonOrLost == 1},
+    check_winner(NewData).
+
+
+check_connected(NewData = #state{challenger_connected = true, challengee_connected = true}) ->
+    {next_state, connected, NewData};
+check_connected(NewData) ->
+    {keep_state, NewData}.
+
+check_winner(NewData) ->
+    case {NewData#state.challenger_won, NewData#state.challengee_won} of
+        {true, true} ->
+            lager:warning("both participants claimed victory"),
+            {stop, normal};
+        {true, false} ->
+            gen_server:cast(NewData#state.challenger_pid, won),
+            gen_server:cast(NewData#state.challengee_pid, lost),
+            {stop, normal};
+        {false, true} ->
+            gen_server:cast(NewData#state.challenger_pid, lost),
+            gen_server:cast(NewData#state.challengee_pid, won),
+            {stop, normal};
+        {false, false} ->
+            %% disconnect?
+            {stop, normal};
+        _ ->
+            {keep_state, NewData}
+    end.
+
+
+
+
+
+

--- a/src/openomf_lobby_match_sup.erl
+++ b/src/openomf_lobby_match_sup.erl
@@ -1,0 +1,25 @@
+-module(openomf_lobby_match_sup).
+
+-behaviour(supervisor).
+
+-export([start_link/0,
+         start_match/3]).
+
+-export([init/1]).
+
+start_link() ->
+      supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+init(_Args) ->
+    SupFlags = #{strategy => simple_one_for_one,
+                 intensity => 0,
+                 period => 1},
+    ChildSpecs = [#{id => openomf_lobby_match,
+                    start => {openomf_lobby_match, start_link, []},
+                    type => worker,
+                    restart => temporary,
+                    shutdown => brutal_kill}],
+    {ok, {SupFlags, ChildSpecs}}.
+
+start_match(ChallengerPid, ChallengerInfo, ChallengeePid) ->
+    supervisor:start_child(?MODULE, [ChallengerPid, ChallengerInfo, ChallengeePid]).

--- a/src/openomf_lobby_sup.erl
+++ b/src/openomf_lobby_sup.erl
@@ -2,8 +2,7 @@
 
 -behaviour(supervisor).
 
--export([start_link/1,
-         start_client/1, client_presence/0]).
+-export([start_link/1]).
 
 -export([init/1]).
 
@@ -11,19 +10,17 @@ start_link(Args) ->
       supervisor:start_link({local, ?MODULE}, ?MODULE, Args).
 
 init(_Args) ->
-    SupFlags = #{strategy => simple_one_for_one,
-                 intensity => 0,
-                 period => 1},
-    ChildSpecs = [#{id => openomf_lobby_client,
-                    start => {openomf_lobby_client, start_link, []},
+    SupFlags = #{strategy => rest_for_one,
+                 intensity => 5,
+                 period => 10},
+    ChildSpecs = [#{id => openomf_lobby_client_sup,
+                    start => {openomf_lobby_client_sup, start_link, []},
                     type => worker,
-                    restart => temporary,
+                    restart => permanent,
+                    shutdown => brutal_kill},
+                 #{id => openomf_lobby_match_sup,
+                    start => {openomf_lobby_match_sup, start_link, []},
+                    type => worker,
+                    restart => permanent,
                     shutdown => brutal_kill}],
     {ok, {SupFlags, ChildSpecs}}.
-
-start_client(PeerInfo) ->
-    supervisor:start_child(?MODULE, [PeerInfo]).
-
-client_presence() ->
-    Children = supervisor:which_children(?MODULE),
-    [ openomf_lobby_client:get_presence(Pid, self()) || {_Id, Pid, _Type, _Modules} <- Children, Pid /= self()].


### PR DESCRIPTION
This lays the groundwork for having the lobby server relay events for matches (when NAT won't allow direct connections) and also for spectate mode.

This also fixes win/loss tracking to only increment stats if both sides report the same result.

Relates to omf2097/openomf#903